### PR TITLE
Fix custom validity rules on IE?

### DIFF
--- a/src/extras/custom-validity.js
+++ b/src/extras/custom-validity.js
@@ -80,9 +80,7 @@
 		
 		
 		//if constraint validation is supported, we have to change validityState as soon as possible
-		if(document.addEventListener && document.createElement('form').checkValidity){
-			document.addEventListener('change', onEventTest, true);
-		}
+		$(document).bind('change', onEventTest);
 		
 		webshims.addReady(function(context, selfElement){
 			initTest = true;


### PR DESCRIPTION
I don't actually know, if `e.stopPropagation()` is necessary (I just added it because of the `true` flag of the old `addEventListener`).

Don't tested it much, but looks like it works. I'll go on testing.
