### PR TITLE
Binds change listener to both sides of a dependent validation

### DIFF
--- a/src/extras/custom-validity.js
+++ b/src/extras/custom-validity.js
@@ -237,6 +237,9 @@
 				$(data.masterElement).bind('change', function(){
 					$.webshims.refreshCustomValidityRules(elem);
 				});
+        $(elem).bind('change', function(){
+          $.webshims.refreshCustomValidityRules(elem);
+        });
 			}
 		}
 


### PR DESCRIPTION
This update fixes dependent-validation in IE < 9 at least.
It probably is necessary for any browser that doesn't support
checkValidity
