### PR TITLE
Form validation: don't show an empty error bubble when field becomes valid

### DIFF
--- a/src/shims/form-core.js
+++ b/src/shims/form-core.js
@@ -531,13 +531,15 @@ jQuery.webshims.register('form-core', function($, webshims, window, document, un
 				}, 10);
 			},
 			getMessage: function(elem, message){
-				if (message === '') {
-					this.hide();
+				if (!message) {
+					message = getContentValidationMessage(elem[0]) || elem.prop('validationMessage');
+				}
+				if (message) {
+					$('span.va-box', errorBubble).text(message);
 				}
 				else {
-					$('span.va-box', errorBubble).text(message || getContentValidationMessage(elem[0]) || elem.prop('validationMessage'));
+					this.hide();
 				}
-				
 			},
 			position: function(elem, offset){
 				offset = offset ? $.extend({}, offset) : api.getOffsetFromBody(elem);


### PR DESCRIPTION
Hello, thank you so much for webshim!

We found a little visual glitch when using webshim form validation implementation.

After the user submits an invalid form, the error bubble is shown with the error message. When the user fixes the problem, the error message is emptied out and the error bubble stays visible without a message. It looks like a weird empty arrow before it fades out a few seconds later.

The goal of this fix is to actually fade out the error bubble rather than emptying it when the field becomes valid.
