### PR TITLE
Add a placeholder to the date field shims

### DIFF
--- a/src/shims/form-number-date-ui.js
+++ b/src/shims/form-number-date-ui.js
@@ -243,7 +243,19 @@ jQuery.webshims.register('form-number-date-ui', function($, webshims, window, do
 			});
 			return data;
 		};
-		
+
+		var setDatePlaceholder = function(shim, settings) {
+			var format;
+
+			if(settings.dateFormat){
+				format = settings.dateFormat
+					.replace(/y+/g, 		'Year')
+					.replace(/(d+|o+|D+)/g, 'Day')
+					.replace(/(m+|M+)/g, 	'Month');
+				shim.attr('placeholder', format);
+			}
+		};
+
 //		replaceInputUI['datetime-local'] = function(elem){
 //			if(!$.fn.datepicker){return;}
 //			
@@ -421,7 +433,8 @@ jQuery.webshims.register('form-number-date-ui', function($, webshims, window, do
 				data = configureDatePicker(elem, date, change)
 				
 			;
-						
+
+			setDatePlaceholder(date, data.settings);
 			if(attr.css){
 				date.css(attr.css);
 				if(attr.outerWidth){


### PR DESCRIPTION
When replacing the date field implementation with webshim forms-ext and the jQueryUI datepicker widget, the text field shim doesn't have a placeholder like the native implementation in Chrome for instance.

Having a placeholder is convenient as it tells the user that this is a date field and what is its format with just a quick glance at the form.

The goal of this pull request is to set a placeholder on all the date fields using the datepicker dateFormat option to figure out its content.

I implemented it for our specific needs, so it is not much configurable. It has the following shortcomings:
- the placeholders can't be unset or overridden
- it only works if using the datepicker widget
- it's English only

I can work on improving the pull request if you're interested in this feature. What do you think?
