### PR TITLE
Change modernizr script reference in How To Use

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,11 @@ How To Use
 
 ---------------
 	<script src="js/jquery.js"></script>
-	<script src="js/Modernizr-yepnope.js"></script> 
+	// Simple change
+	<script src="js-webshim/minified/extras/modernizr-custom.js"></script> 
+	// 'User your own' variant
+	<script src="js/Modernizr-custom.js"></script> 
+
 	<script src="js-webshim/minified/polyfiller.js"></script> 
 
 	<script> 


### PR DESCRIPTION
Neither download or repo include a file named Modernizr-yesnope.js but do include modernizr-custom.js.

If the intent of the How To is to suggest devs may use their own version of Modernizr then this should be more explicitly called out as in my second example.

In either case I'm not at all clear why Modernizr-yesnope.js is used, if I create my own production Modernizr from their build tool I don't get that file.
