### PR TITLE
Clear min/max date on empty/invalid value

### DIFF
--- a/src/shims/form-number-date-ui.js
+++ b/src/shims/form-number-date-ui.js
@@ -451,18 +451,18 @@ jQuery.webshims.register('form-number-date-ui', function($, webshims, window, do
 			min: function(orig, shim, value){
 				try {
 					value = $.datepicker.parseDate('yy-mm-dd', value);
-				} catch(e){value = false;}
-				if(value){
-					$(shim).datepicker('option', 'minDate', value);
+				} catch (e) {
+					value = null;
 				}
+				$(shim).datepicker('option', 'minDate', value);
 			},
 			max: function(orig, shim, value){
 				try {
 					value = $.datepicker.parseDate('yy-mm-dd', value);
-				} catch(e){value = false;}
-				if(value){
-					$(shim).datepicker('option', 'maxDate', value);
+				} catch (e) {
+					value = null;
 				}
+				$(shim).datepicker('option', 'maxDate', value);
 			},
 			'data-placeholder': function(orig, shim, value){
 				var hintValue = (value || '').split('-');


### PR DESCRIPTION
Currently, setting min/max to an empty value does not reset the min/max constraints. As a workaround one can set the date to some insane low date such as 1970-01-01, but this is a hack. webshim should just reset the date limits when empty or unset.
