### PR TITLE
Geolocation polyfill does not work with HTTPS

### DIFF
--- a/src/shims/geolocation.js
+++ b/src/shims/geolocation.js
@@ -85,7 +85,7 @@
 						return;
 					}
 					$.ajax({
-						url: 'http://freegeoip.net/json/',
+						url: '//freegeoip.net/json/',
 						dataType: 'jsonp',
 						cache: true,
 						jsonp: 'callback',
@@ -131,7 +131,7 @@
 								document.writeln = domWrite;
 							}
 							$(document).one('google-loader', googleCallback);
-							$.webshims.loader.loadScript('http://www.google.com/jsapi', false, 'google-loader');
+							$.webshims.loader.loadScript('//www.google.com/jsapi', false, 'google-loader');
 						}, 800);
 					} else {
 						locationAPIs--;


### PR DESCRIPTION
This polyfill does not work with HTTPS requests. For example IE8 reports the following errors:

```
SEC7111: HTTPS security is compromised by http://freegeoip.net/json/?callback=jQuery19108828520477414441_1376291388049
SEC7111: HTTPS security is compromised by http://www.google.com/jsapi
```

Both these reported URLs seem to be accessible via TLS.
- https://www.google.com/jsapi
- https://freegeoip.net/json/

So the easiest solution to me seems to just use schema-less URLs.
