### PR TITLE
getDateArray should add zeros to time as well

### DIFF
--- a/src/shims/forms-picker.js
+++ b/src/shims/forms-picker.js
@@ -8,7 +8,7 @@ webshims.register('forms-picker', function($, webshims, window, document, undefi
 		var ret = [date.getFullYear(), moduleOpts.addZero(date.getMonth() + 1), moduleOpts.addZero(date.getDate())];
 		ret.month = ret[0]+'-'+ret[1];
 		ret.date = ret[0]+'-'+ret[1]+'-'+ret[2];
-		ret.time = date.getHours() +':'+ date.getMinutes();
+		ret.time = moduleOpts.addZero(date.getHours()) +':'+ moduleOpts.addZero(date.getMinutes());
 		
 		ret['datetime-local'] = ret.date +'T'+ ret.time;
 		return ret;


### PR DESCRIPTION
getDateArray is used as the value for ws-current in the popup, and was creating invalid values for the datetime-local data type.
