### PR TITLE
define the isNumber function used in the input maxlength property shim

### DIFF
--- a/src/shims/form-shim-extend2.js
+++ b/src/shims/form-shim-extend2.js
@@ -1,6 +1,9 @@
 webshims.register('form-shim-extend2', function($, webshims, window, document, undefined, options){
 "use strict";
 var emptyJ = $([]);
+var isNumber = function(string){
+    return (typeof string == 'number' || (string && string == string * 1));
+};
 var getGroupElements = function(elem){
 	elem = $(elem);
 	var name;


### PR DESCRIPTION
I had a bug on IE8 when loading the 'forms' shim on the maxlength property shim. 
The reason was, the 'mexlength''s getter was calling a function 'isNumber' which is not defined in the form-shim-extend2.js file.
I just copy/paste a isNumber function form another js file and this fixes the bug. 
