### PR TITLE
Do not print documentation with console.log

### DIFF
--- a/js-webshim/dev/extras/modernizr-custom.js
+++ b/js-webshim/dev/extras/modernizr-custom.js
@@ -505,7 +505,3 @@ window.Modernizr = (function( window, document, undefined ) {
 
 })(this, this.document);
 ;
-if(window.console){
-	console.log('webshim no longer depends on Modernizr. You can still use for feature detection of course.');
-}
-


### PR DESCRIPTION
Printing this documentation notice on every pageload pollutes everything, example on some tests running phantomjs:

![captura de pantalla 2014-07-29 a les 0 55 27](https://cloud.githubusercontent.com/assets/275992/3728442/eaebf8b6-16aa-11e4-82bd-9f612f9a25ca.png)
