### PR TITLE
Fixed replacement tokens in Dutch 18n

### DIFF
--- a/src/shims/i18n/formcfg-nl.js
+++ b/src/shims/i18n/formcfg-nl.js
@@ -28,8 +28,8 @@ webshims.validityMessages.nl = {
 		"month": "Maand moet op of voor {%max} zijn."
 	},
 	"stepMismatch": "Ongeldige invoer.",
-	"tooLong": "Voer maximaal {%maxLength} karakter(s) in. {%valueLen} is te lang.",
-	"tooShort": "Voer minimaal {%minLength} karakter(s) in. {%valueLen} is te kort.",
+	"tooLong": "Voer maximaal {%maxlength} karakter(s) in. {%valueLen} is te lang.",
+	"tooShort": "Voer minimaal {%minlength} karakter(s) in. {%valueLen} is te kort.",
 	"patternMismatch": "Voer een waarde in met de gevraagde opmaak: {%title}.",
 	"valueMissing": {
 		"defaultMessage": "Vul dit veld in.",


### PR DESCRIPTION
Dutch i18n has incorrect replacement tokens for `tooShort` and `tooLong` validation messages.
