### PR TITLE
Update .gitattributes to remove bower.json export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@ js-webshim/minified/extras/ export-ignore
 js-webshim/dev/extras/ export-ignore
 tests/ export-ignore
 Gruntfile.js export-ignore
-bower.json export-ignore
 package.json export-ignore
 webshims.jquery.json export-ignore
 .* export-ignore


### PR DESCRIPTION
If bower.json is excluded then Bower installs are not correctly handled because it downloads release archives that have no bower.json file on them.