### PR TITLE
Added noSpinbtn config option to demo pages.

### DIFF
--- a/demos/demos/cfgs/input-date.html
+++ b/demos/demos/cfgs/input-date.html
@@ -233,6 +233,12 @@
 											<div class="form-group col-sm-12">
 												<div class="checkbox">
 													<label>
+														<input type="checkbox" name="noSpinbtn" />
+														noSpinbtn
+													</label>
+												</div>
+                                                                                                <div class="checkbox">
+													<label>
 														<input type="checkbox" name="inlinePicker" />
 														inlinePicker
 													</label>

--- a/demos/demos/cfgs/input-datetime-local.html
+++ b/demos/demos/cfgs/input-datetime-local.html
@@ -210,6 +210,12 @@
 												</div>
 											</div>
 											<div class="form-group col-sm-12">
+                                                                                            <div class="checkbox">
+                                                                                                <label>
+                                                                                                    <input type="checkbox" name="noSpinbtn" />
+                                                                                                    noSpinbtn
+                                                                                                </label>
+                                                                                            </div>
 												<div class="checkbox">
 													<label>
 														<input type="checkbox" name="inlinePicker" />

--- a/demos/demos/cfgs/input-month.html
+++ b/demos/demos/cfgs/input-month.html
@@ -199,6 +199,12 @@
 											<div class="form-group col-sm-12">
 												<div class="checkbox">
 													<label>
+														<input type="checkbox" name="noSpinbtn" />
+														noSpinbtn
+													</label>
+												</div>
+                                                                                                <div class="checkbox">
+													<label>
 														<input type="checkbox" name="inlinePicker" />
 														inlinePicker
 													</label>

--- a/demos/demos/cfgs/input-number.html
+++ b/demos/demos/cfgs/input-number.html
@@ -201,6 +201,12 @@
 												</div>
 												<div class="checkbox">
 													<label>
+														<input type="checkbox" name="noSpinbtn" />
+														noSpinbtn
+													</label>
+												</div>
+												<div class="checkbox">
+													<label>
 														<input type="checkbox" name="nogrouping" />
 														nogrouping
 													</label>

--- a/demos/demos/cfgs/input-time.html
+++ b/demos/demos/cfgs/input-time.html
@@ -183,6 +183,12 @@
 											<div class="form-group col-sm-12">
 												<div class="checkbox">
 													<label>
+														<input type="checkbox" name="noSpinbtn" />
+														noSpinbtn
+													</label>
+												</div>
+                                                                                                <div class="checkbox">
+													<label>
 														<input type="checkbox" name="inlinePicker" />
 														inlinePicker
 													</label>


### PR DESCRIPTION
The `noSpinbtn` config option for forms-ext is not documented anywhere.
This commit add noSpinbtn config checkbox to all demo page where it's relevant:
- date
- datetime-local
- month
- number
- time

Related issue: #489 