### PR TITLE
Extended "ajaxvalidate", new attribute "fieldName"

### DIFF
--- a/src/shims/form-validators.js
+++ b/src/shims/form-validators.js
@@ -413,12 +413,15 @@ webshims.ready('form-validation', function(){
 		var opts;
 		if(!data.remoteValidate){
 			if(typeof data.ajaxvalidate == 'string'){
-				data.ajaxvalidate = {url: data.ajaxvalidate, depends: $([])};
+				data.ajaxvalidate = {url: data.ajaxvalidate, depends: $([]), fieldName: ''}; // new property to makes server process be independent from input[name|id]
 			} else {
 				data.ajaxvalidate.depends = data.ajaxvalidate.depends ?
 					$(typeof data.ajaxvalidate.depends == 'string' && data.ajaxvalidate.depends.split(' ') || data.ajaxvalidate.depends).map(getId) :
 					$([])
 				;
+				
+				if(!data.ajaxvalidate.fieldName)
+					data.ajaxvalidate.fieldName = data.ajaxvalidatefield || ''; // new data-* attribute => [data-ajaxvalidatefield]
 			}
 
 			data.ajaxvalidate.depends.on('change', function(){
@@ -483,7 +486,8 @@ webshims.ready('form-validation', function(){
 				getData: function(){
 					var data;
 					data = {};
-					data[$.prop(elem, 'name') || $.prop(elem, 'id')] = $(elem).val();
+					// usage of new fieldName property
+					data[opts.fieldName || $.prop(elem, 'name') || $.prop(elem, 'id')] = $(elem).val();
 					opts.depends.each(function(){
 						if($.find.matchesSelector(this, ':invalid')){
 							data = false;


### PR DESCRIPTION
In some development scenarios, developers have to change input[id|name] in different web pages.
Current situations, enforce developers to make input-specific async server validation process for each input[id] or input[name].
Sometimes this server validation process is repetitive and they can not make/write their codes reusable.

By adding new "fieldName" property to "ajaxvalidate" custom validity rule core object, developers can make server codes more reusable and independent from client input[id|name].

Usage 1:
<input type='text' 
    id='Text1' 
    neme='UserID'
    data-ajaxvalidate='path to async server validation handler' 
    data-ajaxvalidatefield='Username' />

Usage 2:
<input type='text' 
    id='Text1' 
    neme='UserID'
    data-ajaxvalidate='{ url: "path to async server validation handler", fieldName: "Username"}' />