### PR TITLE
Prevent implicit return of window.URL function

### DIFF
--- a/src/polyfiller.js
+++ b/src/polyfiller.js
@@ -989,7 +989,7 @@
 
 	addPolyfill('usermedia-core', {
 		f: 'usermedia',
-		test: userMediaTest && window.URL,
+		test: userMediaTest && !!window.URL,
 		d: ['url', DOMSUPPORT]
 	});
 


### PR DESCRIPTION
This prevents the implicit return of window.URL's constructor instead of a simple boolean value for `usermedia-core`'s test. This is important because the polyfiller looks to see if `test` is a function, and if so calls it. The recently released Chrome 53 doesn't allow direct calls to the URL constructor anymore and will throw an error if called directly. So now a lot of people are seeing webshim break and the further load of their JS stack halt.

It looks like the call to URL's constructor has been occurring for a little while now but was hidden because the existence of window.URL is still being verified, even though it was also being erroneously called.